### PR TITLE
fix: ignore .slashrouter-storage folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ coverage/
 package-lock.json
 examples/storage/
 types/
+.*/


### PR DESCRIPTION
Add `.slashrouter-storage` folder to gitignore.
![image](https://user-images.githubusercontent.com/5798170/206874057-79420f78-56af-4fea-85b1-32182b5f3a34.png)
